### PR TITLE
Add DT scripts

### DIFF
--- a/dt-on-set-scripts/Capture One Scripts/add_capture_to_favs.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/add_capture_to_favs.applescript
@@ -1,0 +1,9 @@
+(*
+	Add the current Capture Directory to favorites
+
+	Created by Emory Dunn
+
+*)
+tell front document of application "Capture One 12"
+	set captureCollection to make collection with properties {kind:favorite, file:captures}
+end tell

--- a/dt-on-set-scripts/Capture One Scripts/apply_keywords.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/apply_keywords.applescript
@@ -1,0 +1,63 @@
+(*
+	Apply keywords from the clipboard to all variants in the current collection.
+
+	Each line of text in the clipboard is applied as a separate keyword. The keywords
+	are added to the whatever the current keywords are.
+
+	If you need to remove all keywords, use "Reset Keywords", which will remove all
+	keywords from every variant in the current collection.
+
+	Created by Emory Dunn
+
+*)
+
+use AppleScript version "2.4" -- Yosemite (10.10) or later
+use scripting additions
+
+set theRawKeywords to the clipboard as string
+
+set dialogAnswer to display dialog ¬
+	"Apply " & number of paragraphs of theRawKeywords & " keywords" buttons {"Reset Keywords", "No", "Yes"} ¬
+	default button "Yes"
+if button returned of dialogAnswer is "Yes" then
+	repeat with theLine in paragraphs of theRawKeywords
+		log theLine as string
+		setKeyword(theLine)
+	end repeat
+else if button returned of dialogAnswer is "Reset Keywords" then
+	resetKeywords()
+end if
+
+
+on setKeyword(theKeyword)
+	tell front document of application "Capture One 12"
+		--	Capture One does not allow `,` or `|` in keywords
+		set theCleanKeyword to my replace_chars(theKeyword, ",", " ")
+		set theCleanKeyword to my replace_chars(theCleanKeyword, "|", " ")
+
+		repeat with theVariant in variants of current collection
+			tell theVariant to make keyword with properties {name:theCleanKeyword}
+
+		end repeat
+
+	end tell
+end setKeyword
+
+on resetKeywords()
+	tell front document of application "Capture One 12"
+
+		delete every keyword of every variant of current collection
+
+	end tell
+
+end resetKeywords
+
+-- From https://www.macosxautomation.com/applescript/sbrt/sbrt-06.html
+on replace_chars(this_text, search_string, replacement_string)
+	set AppleScript's text item delimiters to the search_string
+	set the item_list to every text item of this_text
+	set AppleScript's text item delimiters to the replacement_string
+	set this_text to the item_list as string
+	set AppleScript's text item delimiters to ""
+	return this_text
+end replace_chars

--- a/dt-on-set-scripts/Capture One Scripts/batch_rename_collection.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/batch_rename_collection.applescript
@@ -1,0 +1,16 @@
+use AppleScript version "2.4" -- Yosemite (10.10) or later
+use scripting additions
+
+tell front document of application "Capture One 12"
+	--  Sort by date
+	set sorting order of current collection to by date
+	set sorting reversed of current collection to false
+	
+	-- Get current collections variants
+	set theVariants to every variant of current collection
+	log "Renaming " & number of theVariants & " variants"
+	
+	-- Batch rename
+	set counter of batch rename settings to 1
+	batch rename variants theVariants
+end tell

--- a/dt-on-set-scripts/Capture One Scripts/make_new_dir.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/make_new_dir.applescript
@@ -1,0 +1,111 @@
+(*
+	Creates new directories inside of the Capture directory and sets the capture directory.
+
+	When running the script you'll be prompted for a new directory name. The prompt
+	will repeat allowing going back to FileMaker or a spreadsheet, enter an empty string
+	to end the loop.
+
+	New directories are created adjacent to the current capture directory, _unless_
+	the capture directory is "Capture", in which case new folders are made inside.
+
+	Set `repeatPrompt` to `false` to only prompt for one name.
+
+	If `setCaptureFolder` is `true` then the capture directory will be
+	set to the *first* directory name entered.
+
+	Created by Emory Dunn
+
+*)
+
+-- Settings
+set repeatPrompt to true
+set setCaptureFolder to true
+
+-- Script Below
+-- Do Not Modify
+
+set newDirs to getDirs(not repeatPrompt)
+set fullPaths to makeDirs(newDirs)
+addFavorites(fullPaths, setCaptureFolder)
+
+on getDirs(askOnce)
+	-- present a modal asking for a name
+	set newDirs to []
+	set previousAnswer to "nil"
+
+	try
+		repeat while previousAnswer is not ""
+			set theResponse to display dialog ¬
+				"New Folder Name" default answer ¬
+				"" buttons {"Cancel", "Next"} ¬
+				default button ¬
+				"Next" cancel button "Cancel"
+
+			set responseText to text returned of theResponse
+
+			if responseText is not "" then
+				set newDirs to newDirs & responseText
+			end if
+			if askOnce then
+				set previousAnswer to ""
+			else
+				set previousAnswer to responseText
+			end if
+
+		end repeat
+	end try
+	return newDirs
+
+end getDirs
+
+on makeDirs(dirNames)
+	tell front document of application "Capture One 12"
+		set currentCaptureDir to captures
+		tell application "Finder" to set captureName to name of folder currentCaptureDir
+
+		set newDirs to []
+
+		-- if the name is not Capture, we need to create our folder under the main Capture dir
+		if captureName is not "Capture" then
+			tell application "Finder"
+				set d to currentCaptureDir as alias
+				set currentCaptureDir to container of d as alias
+			end tell
+
+		end if
+
+		repeat with newName in dirNames
+			set newDir to POSIX path of currentCaptureDir & newName
+			set newDirs to newDirs & newDir
+
+			tell application "Finder"
+				try
+					log "Making new dir " & newDir
+					make new folder at currentCaptureDir with properties {name:newName}
+				end try
+
+			end tell
+			log newDir
+		end repeat
+
+	end tell
+	return newDirs
+end makeDirs
+
+on addFavorites(dirPaths, setCapture)
+	tell front document of application "Capture One 12"
+
+		set capture counter to 1
+
+		-- Add all paths to favorites
+		repeat with dirPath in dirPaths
+			set captureCollection to make collection with properties {kind:favorite, file:dirPath}
+		end repeat
+
+		if setCapture is true and (count of dirPaths) is greater than 0 then
+			-- Set the first item as the capture folder
+			set captures to first item in dirPaths
+		end if
+	end tell
+
+end addFavorites

--- a/dt-on-set-scripts/Capture One Scripts/select_next_capture.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/select_next_capture.applescript
@@ -1,0 +1,31 @@
+(*
+  Moves the capture directory down the list of favorites
+  relative to the current capture directory.
+
+  Created by Emory Dunn
+*)
+
+tell front document of application "Capture One 12"
+	
+	set theFolder to captures
+	set captureCollection to item 1 of (collections whose folder is theFolder and user is true)
+	--log name of captureCollection as string
+	--log captureCollection
+	
+	try
+		set newCapture to the collection after captureCollection
+		--log name of newCapture as string
+		--log newCapture
+		
+		if file of newCapture is equal to missing value then
+			log "No file for " & name of newCapture as string
+		else
+			log "Setting capture dir to " & name of newCapture
+			set captures to get the file of newCapture
+		end if
+		
+	on error errMsg number errNum
+		log "End of the list"
+	end try
+	
+end tell

--- a/dt-on-set-scripts/Capture One Scripts/select_previous_capture.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/select_previous_capture.applescript
@@ -1,0 +1,31 @@
+(*
+  Moves the capture directory down the list of favorites
+  relative to the current capture directory.
+
+  Created by Emory Dunn
+*)
+
+tell front document of application "Capture One 12"
+	
+	set theFolder to captures
+	set captureCollection to item 1 of (collections whose folder is theFolder and user is true)
+	--log name of captureCollection as string
+	--log captureCollection
+	
+	try
+		set newCapture to the collection before captureCollection
+		--log name of newCapture as string
+		--log newCapture
+		
+		if file of newCapture is equal to missing value then
+			log "No file for " & name of newCapture as string
+		else
+			log "Setting capture dir to " & name of newCapture
+			set captures to get the file of newCapture
+		end if
+		
+	on error errMsg number errNum
+		log "End of the list"
+	end try
+	
+end tell

--- a/dt-on-set-scripts/Capture One Scripts/smart_album_for_selection.applescript
+++ b/dt-on-set-scripts/Capture One Scripts/smart_album_for_selection.applescript
@@ -1,0 +1,42 @@
+--
+--	Created by: Emory Dunn
+--	Created on: 2018-03-13
+--
+--	Copyright © 2018 Emory Dunn, All Rights Reserved
+--
+
+use AppleScript version "2.4" -- Yosemite (10.10) or later
+use scripting additions
+
+on run
+
+	-- Parameters
+	set theDelimiter to "_"
+	set itemNumber to 3
+
+	-- Script below
+
+	tell front document of application "Capture One 12" to set selectedItem to current collection
+
+	set theName to my theSplit(name of selectedItem, theDelimiter)
+	set theNameComponent to item itemNumber of theName
+
+	set theRules to "<?xml version=\"1.0\" encoding=\"UTF-8\"?><MatchOperator Kind=\"AND\"><MatchOperator Kind=\"AND\"><Condition Enabled=\"YES\"><Key>displayName</Key><Operator>6</Operator><Criterion>" & theNameComponent & "</Criterion></Condition></MatchOperator></MatchOperator>"
+
+	tell front document of application "Capture One 12"
+		make new collection with properties {name:theNameComponent, kind:smart album, rules:theRules}
+	end tell
+end run
+
+on theSplit(theString, theDelimiter)
+	-- save delimiters to restore old settings
+	set oldDelimiters to AppleScript's text item delimiters
+	-- set delimiters to delimiter to be used
+	set AppleScript's text item delimiters to theDelimiter
+	-- create the array
+	set theArray to every text item of theString
+	-- restore the old setting
+	set AppleScript's text item delimiters to oldDelimiters
+	-- return the result
+	return theArray
+end theSplit

--- a/dt-on-set-scripts/LICENSE
+++ b/dt-on-set-scripts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Emory Dunn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dt-on-set-scripts/README.md
+++ b/dt-on-set-scripts/README.md
@@ -1,0 +1,77 @@
+# CaptureOneScripts
+A collection of AppleScripts for use with Capture One.
+
+| Script                    | Compatability | Shortcut       |
+|---------------------------|--------------:|----------------:|
+| add_capture_to_favs       | 9+            | <kbd>⌃f</kbd>
+| apply_keywords            | 10+           | <kbd>⇧⌘K</kbd>
+| batch_rename_collection   | 12            |
+| make_new_dir              | 9+            | <kbd>⌃n</kbd>
+| select_next_capture       | 12            | <kbd>⌃↑</kbd>
+| select_previous_capture   | 12            | <kbd>⌃↓</kbd>
+| smart_album_for_selection | 9+            |
+
+
+## Installation
+
+Run `install.command`, which will copy the scripts to `~/Library/Scripts/Capture One Scripts` and set up the keyboard shortcuts.
+
+Some notes:
+
+- The script defaults to adding shortcuts for Capture One 20.
+- Capture One should be restarted after installation
+- MacOS might not show the shortcuts in System Preferences.
+
+
+## The Scripts
+
+### Add Capture to Favs
+
+Adds the current Capture Directory to favorites
+
+### Apply Keywords
+
+Apply keywords from the clipboard to all variants in the current collection.
+
+Each line of text in the clipboard is applied as a separate keyword. The keywords are added to the whatever the current keywords are.
+
+If you need to remove all keywords, use "Reset Keywords", which will remove all
+keywords from every variant in the current collection.
+
+### Make New Dir
+
+Creates new directories inside of the Capture directory and sets the capture directory.
+
+When running the script you'll be prompted for a new directory name. The prompt
+will repeat allowing going back to FileMaker or a spreadsheet, enter an empty string to end the loop.
+
+New directories are created adjacent to the current capture directory, _unless_
+the capture directory is "Capture", in which case new folders are made inside.
+
+  Set `repeatPrompt` to `false` to only prompt for one name.
+
+  If `setCaptureFolder` is `true` then the capture directory will be
+  set to the *first* directory name entered.
+
+### Select Next/ Previous Capture
+
+Moves the capture directory up or down the list of favorites relative to the current capture directory.
+
+_Note_: The new versions of these scripts will only work in Capture One 12 and later.
+
+[favorite_order]: https://emorydunn.com/2018/02/27/Capture-One-Collections-and-AppleScript
+
+### Smart Album For Selection
+
+Creates a smart album from the name of the selected album.
+
+There are two parameters for configuring the search terms:
+
+- `theDelimiter`, default `_`
+- `itemNumber`, default `3`
+
+The script splits the name on the delimiter and selects the `itemNumber` item in the new list for the search term. For instance, `some_file_name` would have a smart album called `name` made for it.
+
+### Batch Rename Collection
+
+Sorts the current collection by date (ascending), sets the rename counter to 1, and renames all variants.

--- a/dt-on-set-scripts/install.command
+++ b/dt-on-set-scripts/install.command
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+SCRIPT_DIR=`dirname "${0}"`
+INSTALL_DIR="${HOME}/Library/Scripts/Capture One Scripts"
+CAPTUREONE="com.captureone.captureone13"
+
+ADD_SHORTCUT="defaults write ${CAPTUREONE} NSUserKeyEquivalents -dict-add"
+
+
+echo "Copying scripts..."
+for d in "${SCRIPT_DIR}/Capture One Scripts"/*.applescript ; do \
+  echo "  ${d}"
+  cp "${d}" "${INSTALL_DIR}"
+done
+
+echo "Setting keyboard shortcuts..."
+${ADD_SHORTCUT} "Scriptsapply_keywords" "@\$k"
+
+${ADD_SHORTCUT} "Scriptsmake_new_dir" "^n"
+
+${ADD_SHORTCUT} "Scriptsselect_previous_capture" "^↑"
+${ADD_SHORTCUT} "Scriptsselect_next_capture" "^↓"
+
+${ADD_SHORTCUT} "Scriptsadd_capture_to_favs" "^f"
+echo "Done"


### PR DESCRIPTION
I'm making a PR for these so I can get potential feedback on the file organization. Most of my scripts have keyboard shortcuts associated with them and a little installer script to set them up. However, it does break the convention of each script having its own folder. 

Is everyone fine with breaking the convention a little bit? 